### PR TITLE
Updated Faster Raid Progression mod to 1.5 ver.

### DIFF
--- a/Mods/Faster raids progression/About/About.xml
+++ b/Mods/Faster raids progression/About/About.xml
@@ -5,6 +5,7 @@
 	<supportedVersions>
 		<li>1.3</li>
 		<li>1.4</li>
+		<li>1.5</li>
 	</supportedVersions>
 	<packageId>arpomo6.hmpc.fasterraidsprogression</packageId>
 	<description>

--- a/Mods/Faster raids progression/About/About.xml
+++ b/Mods/Faster raids progression/About/About.xml
@@ -10,9 +10,9 @@
 	<packageId>arpomo6.hmpc.fasterraidsprogression</packageId>
 	<description>
 (ENG)
-The modification speeds up the progress of raids. High-tech factions will start appearing much earlier, low-tech ones will attack less often in the late game. Can be safely turned on or off on existing colonies. The mod does not affect pirate and mechanoid factions for ethical reasons.
+The modification speeds up the progress of raids. High-tech factions will start appearing much earlier, low-tech ones will attack less often in the late game. Can be safely turned on or off on existing colonies. The mod does not affect pirate and mechanoid factions for ethical reasons.\n\nWARNING: This modification can significantly complicate the game. Enable at your own risk.\n\n
 (RUS)
-Модификация ускоряет прогресс рейдов. Высокотехнологичные фракции начнут появляться заметно раньше, низкотехнологичные станут реже нападать на поздней стадии игры. Может быть безопасно включен или выключен на существующих колониях. Мод не затрагивает фракцию пиратов и механоидов по этическим соображениям.
+Модификация ускоряет прогресс рейдов. Высокотехнологичные фракции начнут появляться заметно раньше, низкотехнологичные станут реже нападать на поздней стадии игры. Может быть безопасно включен или выключен на существующих колониях. Мод не затрагивает фракцию пиратов и механоидов по этическим соображениям.\n\nВНИМАНИЕ: эта модификация может значительно усложнить игру. Включайте на свой страх и риск.
 	</description>
 	<modDependencies>
 	</modDependencies>

--- a/Mods/Faster raids progression/Patches/AsariRace_Faction_Patch.xml
+++ b/Mods/Faster raids progression/Patches/AsariRace_Faction_Patch.xml
@@ -11,7 +11,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/FactionDef[defName="AsariHunters"]/earliestRaidDays</xpath>
 					<value>
-						<earliestRaidDays>110</earliestRaidDays>
+						<earliestRaidDays>145</earliestRaidDays>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -20,12 +20,12 @@
 						<raidCommonalityFromPointsCurve>
 							<points>
 								<li>(0, 0.001)</li>
-								<li>(2000, 0.02)</li>
-								<li>(6500, 0.10)</li>
-								<li>(7500, 0.9)</li>
-								<li>(9000, 1.0)</li>
-								<li>(12000, 1.1)</li>
-								<li>(17000, 1.0)</li>
+								<li>(2250, 0.02)</li>
+								<li>(8000, 0.10)</li>
+								<li>(9000, 0.9)</li>
+								<li>(10500, 1.0)</li>
+								<li>(13500, 1.1)</li>
+								<li>(18500, 1.0)</li>
 							</points>
 						</raidCommonalityFromPointsCurve>
 					</value>

--- a/Mods/Faster raids progression/Patches/HMC_Faction_Patch.xml
+++ b/Mods/Faster raids progression/Patches/HMC_Faction_Patch.xml
@@ -11,7 +11,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/FactionDef[defName="NorbalHighTech"]/earliestRaidDays</xpath>
 					<value>
-						<earliestRaidDays>180</earliestRaidDays>
+						<earliestRaidDays>270</earliestRaidDays>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -20,10 +20,11 @@
 						<raidCommonalityFromPointsCurve>
 							<points>
 								<li>(5000, 0)</li>
-								<li>(7000, 0.3)</li>
-								<li>(8500, 0.7)</li>
-								<li>(10000, 1.0)</li>
-								<li>(17000, 0.8)</li>
+								<li>(9000, 0.3)</li>
+								<li>(11000, 0.7)</li>
+								<li>(12500, 1.0)</li>
+								<li>(18000, 2.0)</li>
+								<li>(20000, 0.8)</li>
 							</points>
 						</raidCommonalityFromPointsCurve>
 					</value>
@@ -34,9 +35,9 @@
 						<maxPawnCostPerTotalPointsCurve>
 							<points>
 								<li>(0,400)</li>
-								<li>(7500, 450)</li>
-								<li>(9500, 500)</li>
-								<li>(11000, 550)</li>
+								<li>(9500, 470)</li>
+								<li>(11500, 525)</li>
+								<li>(13000, 570)</li>
 								<li>(100000, 10000)</li>
 							</points>
 						</maxPawnCostPerTotalPointsCurve>
@@ -46,7 +47,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/FactionDef[defName="DrugCatsHMC"]/earliestRaidDays</xpath>
 					<value>
-						<earliestRaidDays>155</earliestRaidDays>
+						<earliestRaidDays>210</earliestRaidDays>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -55,10 +56,11 @@
 						<raidCommonalityFromPointsCurve>
 							<points>
 								<li>(4000, 0)</li>
-								<li>(6000, 0.4)</li>
-								<li>(8500, 0.6)</li>
-								<li>(10000, 0.9)</li>
-								<li>(12000, 0.7)</li>
+								<li>(8000, 0.4)</li>
+								<li>(10500, 0.6)</li>
+								<li>(12000, 0.9)</li>
+								<li>(13000, 1.8)</li>
+								<li>(15000, 0.7)</li>
 							</points>
 						</raidCommonalityFromPointsCurve>
 					</value>
@@ -68,9 +70,9 @@
 					<value>
 						<maxPawnCostPerTotalPointsCurve>
 							<points>
-								<li>(0,300)</li>
-								<li>(6500, 325)</li>
-								<li>(9000, 350)</li>
+								<li>(0,330)</li>
+								<li>(8500, 355)</li>
+								<li>(11000, 380)</li>
 								<li>(100000, 10000)</li>
 							</points>
 						</maxPawnCostPerTotalPointsCurve>
@@ -80,7 +82,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/FactionDef[defName="IgufHMC"]/earliestRaidDays</xpath>
 					<value>
-						<earliestRaidDays>240</earliestRaidDays>
+						<earliestRaidDays>450</earliestRaidDays>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -90,10 +92,10 @@
 							<points>
 								<li>(4000, 0)</li>
 								<li>(7000, 0)</li>
-								<li>(11000, 0.3)</li>
-								<li>(12250, 0.6)</li>
-								<li>(13500, 0.9)</li>
-								<li>(17000, 1.15)</li>
+								<li>(13000, 0.3)</li>
+								<li>(14250, 0.6)</li>
+								<li>(15500, 0.9)</li>
+								<li>(20000, 1.15)</li>
 							</points>
 						</raidCommonalityFromPointsCurve>
 					</value>
@@ -104,10 +106,51 @@
 						<maxPawnCostPerTotalPointsCurve>
 							<points>
 								<li>(0,500)</li>
-								<li>(8000, 725)</li>
-								<li>(11500, 750)</li>
-								<li>(14000, 775)</li>
-								<li>(17000, 800)</li>
+								<li>(10000, 765)</li>
+								<li>(13500, 790)</li>
+								<li>(16000, 815)</li>
+								<li>(20000, 840)</li>
+								<li>(100000, 10000)</li>
+							</points>
+						</maxPawnCostPerTotalPointsCurve>
+					</value>
+				</li>
+				<!-- Knights of the round barrel -->
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/FactionDef[defName="HMC_KotRB"]/earliestRaidDays</xpath>
+					<value>
+						<earliestRaidDays>165</earliestRaidDays>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/FactionDef[defName="HMC_KotRB"]/raidCommonalityFromPointsCurve</xpath>
+					<value>
+						<raidCommonalityFromPointsCurve>
+							<points>
+								<li>(0, 0)</li>
+								<li>(1000, 0)</li>
+								<li>(1800, 0.25)</li>
+								<li>(2700, 0.5)</li>
+								<li>(3600, 1.0)</li>
+								<li>(6400, 2.0)</li>
+								<li>(7200, 0.7)</li>
+								<li>(9600, 0.4)</li>
+								<li>(13500, 0.2)</li>
+								<li>(20000, 0.1)</li>
+							</points>
+						</raidCommonalityFromPointsCurve>
+					</value>
+				</li>
+				<li Class="PatchOperationReplace">
+					<xpath>Defs/FactionDef[defName="HMC_KotRB"]/maxPawnCostPerTotalPointsCurve</xpath>
+					<value>
+						<maxPawnCostPerTotalPointsCurve>
+							<points>
+								<li>(0, 0)</li>
+								<li>(1000, 0)</li>
+								<li>(1800, 150)</li>
+								<li>(2700, 225)</li>
+								<li>(5400, 250)</li>
 								<li>(100000, 10000)</li>
 							</points>
 						</maxPawnCostPerTotalPointsCurve>

--- a/Mods/Faster raids progression/Patches/HSK_Faction_Patch.xml
+++ b/Mods/Faster raids progression/Patches/HSK_Faction_Patch.xml
@@ -7,7 +7,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="Brotherhood"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>75</earliestRaidDays>
+					<earliestRaidDays>110</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -16,11 +16,11 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(0, 0.01)</li>
-							<li>(3000, 0.05)</li>
-							<li>(5000, 0.2)</li>
-							<li>(6500, 1.2)</li>
-							<li>(8000, 1.0)</li>
-							<li>(13000, 0.7)</li>
+							<li>(4000, 0.05)</li>
+							<li>(6000, 0.2)</li>
+							<li>(7500, 1.2)</li>
+							<li>(9000, 1.0)</li>
+							<li>(15000, 0.7)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -31,8 +31,8 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(0, 220)</li>
-							<li>(5000, 240)</li>
-							<li>(8000, 370)</li>
+							<li>(6000, 240)</li>
+							<li>(9000, 370)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -43,7 +43,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="Feral"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>40</earliestRaidDays>
+					<earliestRaidDays>55</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -52,12 +52,12 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(0, 0.01)</li>
-							<li>(3000, 0.05)</li>
-							<li>(4000, 0.5)</li>
-							<li>(5000, 1.2)</li>
-							<li>(6000, 1.0)</li>
-							<li>(8000, 0.7)</li>
-							<li>(13000, 0.5)</li>
+							<li>(4000, 0.05)</li>
+							<li>(5000, 0.5)</li>
+							<li>(6000, 1.2)</li>
+							<li>(7000, 1.0)</li>
+							<li>(9000, 0.7)</li>
+							<li>(15000, 0.5)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -68,9 +68,9 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(0, 160)</li>
-							<li>(3000, 160)</li>
-							<li>(3500, 190)</li>
-							<li>(5000, 290)</li>
+							<li>(4000, 160)</li>
+							<li>(4500, 190)</li>
+							<li>(6000, 290)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -81,7 +81,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="MedievalKingdom"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>25</earliestRaidDays>
+					<earliestRaidDays>27</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -90,12 +90,12 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(200, 3)</li>
-							<li>(1500, 1.2)</li>
-							<li>(3000, 0.8)</li>
-							<li>(4000, 0.5)</li>
-							<li>(6000, 0.6)</li>
-							<li>(8000, 0.3)</li>
-							<li>(13000, 0.05)</li>
+							<li>(1750, 1.2)</li>
+							<li>(3500, 0.8)</li>
+							<li>(4250, 0.5)</li>
+							<li>(6500, 0.6)</li>
+							<li>(9000, 0.3)</li>
+							<li>(15000, 0.05)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -106,7 +106,7 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(0, 120)</li>
-							<li>(1500, 240)</li>
+							<li>(1750, 240)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -117,7 +117,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="NorbalTribe"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>10</earliestRaidDays>
+					<earliestRaidDays>12</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -126,12 +126,12 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(0, 3)</li>
-							<li>(1000, 1.5)</li>
-							<li>(2000, 0.9)</li>
-							<li>(3500, 0.7)</li>
-							<li>(5500, 0.5)</li>
-							<li>(7500, 0.3)</li>
-							<li>(12000, 0.05)</li>
+							<li>(1250, 1.5)</li>
+							<li>(2250, 0.9)</li>
+							<li>(4000, 0.7)</li>
+							<li>(6250, 0.5)</li>
+							<li>(9000, 0.3)</li>
+							<li>(15000, 0.05)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -143,8 +143,8 @@
 						<points>
 							<li>(0,100)</li>
 							<li>(500, 130)</li>
-							<li>(1000, 180)</li>
-							<li>(3500, 190)</li>
+							<li>(1250, 180)</li>
+							<li>(4000, 190)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -155,7 +155,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="NovaAlliance"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>80</earliestRaidDays>
+					<earliestRaidDays>100</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -164,11 +164,11 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(0, 0.01)</li>
-							<li>(3500, 0.05)</li>
-							<li>(6000, 0.7)</li>
-							<li>(7000, 1.2)</li>
-							<li>(8500, 0.8)</li>
-							<li>(13500, 0.6)</li>
+							<li>(4000, 0.05)</li>
+							<li>(6500, 0.7)</li>
+							<li>(7250, 1.2)</li>
+							<li>(9000, 0.8)</li>
+							<li>(15000, 0.6)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -179,8 +179,8 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(0, 200)</li>
-							<li>(3500, 220)</li>
-							<li>(5000, 450)</li>
+							<li>(4000, 220)</li>
+							<li>(5500, 450)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -191,7 +191,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="OgreMutants"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>120</earliestRaidDays>
+					<earliestRaidDays>135</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -201,10 +201,10 @@
 						<points>
 							<li>(0, 0.01)</li>
 							<li>(3000, 0.15)</li>
-							<li>(6500, 0.25)</li>
-							<li>(7000, 0.7)</li>
-							<li>(12000, 1.0)</li>
-							<li>(17000, 1.1)</li>
+							<li>(8000, 0.25)</li>
+							<li>(9000, 0.7)</li>
+							<li>(13500, 1.0)</li>
+							<li>(20000, 1.1)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -215,7 +215,7 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(0, 375)</li>
-							<li>(6500, 800)</li>
+							<li>(7000, 800)</li>
 							<li>(100000,10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -226,7 +226,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="Orion"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>170</earliestRaidDays>
+					<earliestRaidDays>190</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -236,10 +236,10 @@
 						<points>
 							<li>(0, 0.001)</li>
 							<li>(2500, 0.01)</li>
-							<li>(8000, 0.1)</li>
-							<li>(9000, 0.9)</li>
-							<li>(12000, 1.1)</li>
-							<li>(17000, 1.0)</li>
+							<li>(10000, 0.1)</li>
+							<li>(11000, 0.9)</li>
+							<li>(14000, 1.1)</li>
+							<li>(20000, 1.0)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -251,7 +251,7 @@
 						<points>
 							<li>(0, 400)</li>
 							<li>(10000, 470)</li>
-							<li>(14000, 530)</li>
+							<li>(16000, 530)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -262,7 +262,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="Syndicate"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>165</earliestRaidDays>
+					<earliestRaidDays>180</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -272,10 +272,10 @@
 						<points>
 							<li>(0, 0.001)</li>
 							<li>(2500, 0.02)</li>
-							<li>(7500, 0.15)</li>
-							<li>(8500, 0.9)</li>
-							<li>(11500, 1.1)</li>
-							<li>(17000, 1.0)</li>
+							<li>(9500, 0.15)</li>
+							<li>(10500, 0.9)</li>
+							<li>(13750, 1.1)</li>
+							<li>(20000, 1.0)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -287,7 +287,7 @@
 						<points>
 							<li>(0, 400)</li>
 							<li>(10000, 470)</li>
-							<li>(13500, 530)</li>
+							<li>(15500, 530)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -298,7 +298,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="Predators"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>35</earliestRaidDays>
+					<earliestRaidDays>36</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -307,12 +307,12 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(0, 0.01)</li>
-							<li>(3000, 0.05)</li>
-							<li>(4000, 1.4)</li>
-							<li>(6000, 1.0)</li>
-							<li>(8000, 0.7)</li>
-							<li>(12000, 0.3)</li>
-							<li>(17000, 0.1)</li>
+							<li>(3250, 0.05)</li>
+							<li>(4250, 1.4)</li>
+							<li>(6250, 1.0)</li>
+							<li>(8750, 0.7)</li>
+							<li>(14000, 0.3)</li>
+							<li>(20000, 0.1)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -323,9 +323,9 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(1500, 160)</li>
-							<li>(4800, 160)</li>
-							<li>(5000, 190)</li>
-							<li>(5500, 250)</li>
+							<li>(5800, 160)</li>
+							<li>(6000, 190)</li>
+							<li>(6500, 250)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>
@@ -336,7 +336,7 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/FactionDef[defName="Sectarian"]/earliestRaidDays</xpath>
 				<value>
-					<earliestRaidDays>78</earliestRaidDays>
+					<earliestRaidDays>87</earliestRaidDays>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -345,11 +345,11 @@
 					<raidCommonalityFromPointsCurve>
 						<points>
 							<li>(0, 0.01)</li>
-							<li>(3000, 0.05)</li>
-							<li>(5000, 0.3)</li>
-							<li>(6000, 1.3)</li>
-							<li>(8000, 1.1)</li>
-							<li>(13000, 0.7)</li>
+							<li>(4250, 0.05)</li>
+							<li>(6200, 0.3)</li>
+							<li>(7150, 1.3)</li>
+							<li>(9100, 1.1)</li>
+							<li>(15000, 0.7)</li>
 						</points>
 					</raidCommonalityFromPointsCurve>
 				</value>
@@ -360,8 +360,8 @@
 					<maxPawnCostPerTotalPointsCurve>
 						<points>
 							<li>(0, 220)</li>
-							<li>(5000, 240)</li>
-							<li>(8000, 370)</li>
+							<li>(6200, 240)</li>
+							<li>(9100, 370)</li>
 							<li>(100000, 10000)</li>
 						</points>
 					</maxPawnCostPerTotalPointsCurve>

--- a/Mods/Faster raids progression/Patches/RatkinRaceHSK_Faction_Patch.xml
+++ b/Mods/Faster raids progression/Patches/RatkinRaceHSK_Faction_Patch.xml
@@ -10,7 +10,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/FactionDef[@Name="RatkinFactionBase"]/earliestRaidDays</xpath>
 					<value>
-						<earliestRaidDays>60</earliestRaidDays>
+						<earliestRaidDays>96</earliestRaidDays>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -18,14 +18,14 @@
 					<value>
 						<raidCommonalityFromPointsCurve>
 							<points>
-								<li>(500, 0.1)</li>
+								<li>(750, 0.1)</li>
 								<li>(1500, 0.2)</li>
 								<li>(2500, 0.3)</li>
-								<li>(3000, 0.5)</li>
-								<li>(4000, 0.7)</li>
-								<li>(5000, 0.6)</li>
-								<li>(6500, 0.5)</li>
-								<li>(11000, 0.4)</li>
+								<li>(3200, 0.5)</li>
+								<li>(4300, 0.7)</li>
+								<li>(5400, 0.6)</li>
+								<li>(6800, 0.5)</li>
+								<li>(12500, 0.4)</li>
 							</points>
 						</raidCommonalityFromPointsCurve>
 					</value>
@@ -36,12 +36,12 @@
 						<maxPawnCostPerTotalPointsCurve>
 							<points>
 								<li>(0, 160)</li>
-								<li>(3500, 215)</li>
-								<li>(4500, 265)</li>
-								<li>(6000, 290)</li>
-								<li>(8000, 325)</li>
-								<li>(9000, 350)</li>
-								<li>(10000, 400)</li>
+								<li>(4300, 215)</li>
+								<li>(5400, 265)</li>
+								<li>(6800, 290)</li>
+								<li>(8900, 325)</li>
+								<li>(10000, 350)</li>
+								<li>(11750, 400)</li>
 								<li>(100000, 10000)</li>
 							</points>
 						</maxPawnCostPerTotalPointsCurve>
@@ -56,7 +56,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/IncidentDef[defName="RatkinTunnel_Guerrilla"]/earliestDay</xpath>
 					<value>
-						<earliestDay>230</earliestDay>
+						<earliestDay>245</earliestDay>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">

--- a/Mods/Faster raids progression/Patches/Skynet_SK_Faction_Patch.xml
+++ b/Mods/Faster raids progression/Patches/Skynet_SK_Faction_Patch.xml
@@ -10,7 +10,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/FactionDef[defName="SkynetHumanlike"]/earliestRaidDays</xpath>
 					<value>
-						<earliestRaidDays>140</earliestRaidDays>
+						<earliestRaidDays>180</earliestRaidDays>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
@@ -19,10 +19,10 @@
 						<raidCommonalityFromPointsCurve>
 							<points>
 								<li>(0, 0)</li>
-								<li>(8000, 0)</li>
-								<li>(9000, 0.7)</li>
-								<li>(13000, 1.1)</li>
-								<li>(17000, 1.15)</li>
+								<li>(10000, 0)</li>
+								<li>(11000, 0.7)</li>
+								<li>(15000, 1.1)</li>
+								<li>(20000, 1.15)</li>
 							</points>
 						</raidCommonalityFromPointsCurve>
 					</value>
@@ -33,9 +33,9 @@
 						<maxPawnCostPerTotalPointsCurve>
 							<points>
 								<li>(0,600)</li>
-								<li>(11500,650)</li>
-								<li>(14000,1000)</li>
-								<li>(17000,1750)</li>
+								<li>(13500,650)</li>
+								<li>(16000,1000)</li>
+								<li>(18500,1750)</li>
 								<li>(100000,10000)</li>
 							</points>
 						</maxPawnCostPerTotalPointsCurve>
@@ -44,7 +44,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/IncidentDef[defName="Salvation" or defName="AgentPodCrash" or defName="AgentTravelerGroup"]/earliestDay</xpath>
 					<value>
-						<earliestDay>140</earliestDay>
+						<earliestDay>160</earliestDay>
 					</value>
 				</li>
 			</operations>


### PR DESCRIPTION
Updated Faster Raid Progression mod to 1.5 ver. Mod now has a slightly smaller impact on raid development than before, but it is still quite noticeable.

Обновление модификации Faster Raid Progression на версию 1.5. Модификация теперь оказывает немного меньшее влияние на развитие рейдов чем раньше, но все ещё довольно заметное.